### PR TITLE
Bio 컴포넌트에 summary 중앙 정렬

### DIFF
--- a/src/components/Bio.tsx
+++ b/src/components/Bio.tsx
@@ -105,5 +105,6 @@ const StyledSummary = styled.p`
 
   @media screen and (max-width: 650px) {
     font-size: 12px;
+    text-align: center;
   }
 `;


### PR DESCRIPTION
Bio 컴포넌트에 summary 중앙 정렬이 안돼 있어 불편해서 중앙정렬해봤습니다 ㅎㅎ

<img width="285" alt="스크린샷 2023-10-09 오후 11 24 12" src="https://github.com/SEOKKAMONI/gatsby-starter-bbang-blog/assets/102217839/7288d59f-26b9-40f8-b4dc-97b04ea02a53">
